### PR TITLE
Make buttons in hero in row

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en" data-theme="dark">
   <head>
     <script defer src="script.js"></script>
@@ -34,12 +34,14 @@
         <img src="images/icon.png" alt="AxolotlClient logo" />
         <h1>AxolotlClient</h1>
         <h3>A Free & Open-source Minecraft Client</h3>
-        <a href="https://modrinth.com/mod/axolotlclient/versions#all-versions"
-          ><button class="tooltip">Download</button></a
-        >
-        <a href="https://modrinth.com/mod/axolotlclient/gallery"
-          ><button>Screenshots</button></a
-        >
+        <div class="row">
+          <a href="https://modrinth.com/mod/axolotlclient/versions#all-versions"
+            ><button class="tooltip">Download</button></a
+          >
+          <a href="https://modrinth.com/mod/axolotlclient/gallery"
+            ><button>Screenshots</button></a
+          >
+        </div>
       </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -108,30 +108,19 @@ body {
   color: var(--main-text);
   cursor: pointer;
   flex-shrink: 0;
-  font-family:
-    "Inter UI",
-    "SF Pro Display",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    "Open Sans",
-    "Helvetica Neue",
+  font-family: "Inter UI", "SF Pro Display", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
     sans-serif;
   font-size: 16px;
   font-weight: 500;
   height: 4rem;
-  padding: 0 1.6rem;
+  padding: 0 2.5rem;
   text-align: center;
   text-shadow: rgba(0, 0, 0, 0.25) 0 3px 8px;
   transition: all 1s;
   user-select: none;
   -webkit-user-select: none;
   touch-action: manipulation;
-  width: 50%;
   min-height: 7vh;
   height: 9vh;
   text-decoration: none;
@@ -142,9 +131,22 @@ body {
   transition-duration: 0.5s;
 }
 
+.main .buttons {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
 @media (min-width: 768px) {
   .button-36 {
     padding: 0 2.6rem;
+  }
+}
+
+@media (max-width: 500px) {
+  .main .buttons .row {
+    flex-direction: column;
   }
 }
 
@@ -315,4 +317,9 @@ body {
 
 .policy a:visited {
   color: var(--highlight2-color);
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
 }


### PR DESCRIPTION
This PR makes button on main page's here in row, I think it looks way more better like that.

## Before
![before](https://github.com/user-attachments/assets/6f3714b9-bcb7-460c-86f3-79924fd48815)

## After 
![after](https://github.com/user-attachments/assets/b989febd-9a1d-47cc-b6f1-2605329ac7df)

On mobile devices, buttons will go back to column